### PR TITLE
Update background.js: Support subdomains of udemy

### DIFF
--- a/background.js
+++ b/background.js
@@ -48,7 +48,7 @@ chrome.webRequest.onBeforeRequest.addListener(
     }
   },
   {
-    urls: ["*://www.udemy.com/*"]
+    urls: ["*://*.udemy.com/*"]
   },
   ["blocking"]
 );

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "Udemy Custom Speed Changer",
 	"description": "Change Udemy's video player to allow any custom speed.",
-	"version": "2.1.2",
+	"version": "2.1.3",
 	"options_page": "options.html",
 	"manifest_version": 2,
 	"permissions": [


### PR DESCRIPTION
The extension currently doesn't work on subdomains of udemy such as \*.udemy.com/\*